### PR TITLE
Remove `c:bars`, add support for Supplementaries's Gold Bars

### DIFF
--- a/common/src/main/resources/data/c/tags/block/bars.json
+++ b/common/src/main/resources/data/c/tags/block/bars.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:iron_bars"
-  ]
-}

--- a/common/src/main/resources/data/connectiblechains/tags/block/chain_connectible.json
+++ b/common/src/main/resources/data/connectiblechains/tags/block/chain_connectible.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "#c:bars",
+    "minecraft:iron_bars",
     "#minecraft:walls",
     "#minecraft:fences",
     {
@@ -10,6 +10,10 @@
     },
     {
       "id": "supplementaries:sign_post",
+      "required": false
+    },
+    {
+      "id": "supplementaries:gold_bars",
       "required": false
     }
   ]


### PR DESCRIPTION
See https://github.com/evanbones/Reconnectible-Chains/issues/10

Should be easy to backport to other branches